### PR TITLE
use jsonify to set response headers correctly

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ async def add_todo(username):
 
 @app.get("/todos/<string:username>")
 async def get_todos(username):
-    return quart.Response(response=json.dumps(_TODOS.get(username, [])), status=200)
+    return return quart.jsonify(_TODOS.get(username, []))
 
 @app.delete("/todos/<string:username>")
 async def delete_todo(username):


### PR DESCRIPTION
small fix, but with the current implementation response headers are not set to `application/json` on `/todos/$USERNAME`. we can use `.jsonify` to set headers to `application/json` automatically.