### PR TITLE
Add deploy to Replit support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Once the local server is running:
 
 The plugin should now be installed and enabled! You can start with a question like "What is on my todo list" and then try adding something to it as well! 
 
+## Deploy
+
+Fork the Todo list ChatGPT plugin app on Replit [here](https://replit.com/@bardia/ChatGPT-Todo-Plugin).
+
 ## Getting help
 
 If you run into issues or have questions building a plugin, please join our [Developer community forum](https://community.openai.com/c/chat-plugins/20).

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The plugin should now be installed and enabled! You can start with a question li
 
 ## Deploy
 
-Fork the Todo list ChatGPT plugin app on Replit [here](https://replit.com/@bardia/ChatGPT-Todo-Plugin).
+[![Run on Replit](https://replit.com/badge?caption=Run%20on%20Replit)](https://replit.com/@bardia/ChatGPT-Todo-Plugin)
 
 ## Getting help
 


### PR DESCRIPTION
This PR adds support for running and deploying the todo plugin on Replit