### PR TITLE
Insert codespace name

### DIFF
--- a/.devcontainer/addcodespacename.sh
+++ b/.devcontainer/addcodespacename.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Determine the value of SITE_HOST based on whether the project is opened in a Codespace
+if [ -z ${CODESPACE_NAME+x} ]; then
+	SITE_HOST="http://localhost:5003"
+else
+	SITE_HOST="https://${CODESPACE_NAME}-5003.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}"
+fi
+
+# Replace "localhost:5003" with the value of SITE_HOST in the ai-plugin.json file
+sed -i "s#http://localhost:5003#${SITE_HOST}#g" .well-known/ai-plugin.json
+
+# Replace "localhost:5003" with the value of SITE_HOST in the openapi.yaml file
+sed -i "s#http://localhost:5003#${SITE_HOST}#g" openapi.yaml

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,12 +10,9 @@
 	"forwardPorts": [
 		5003
 	],
-	"runArgs": [
-		"-c", "chmod +x ${containerWorkspaceFolder}/.devcontainer/addcodespacename.sh"
-	],
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "pip install -r requirements.txt",
-	"postAttachCommand": "${containerWorkspaceFolder}/.devcontainer/addcodespacename.sh; python main.py",
+	"postAttachCommand": "chmod +x ${containerWorkspaceFolder}/.devcontainer/addcodespacename.sh; ${containerWorkspaceFolder}/.devcontainer/addcodespacename.sh; python main.py",
 	"customizations": {
 		"codespaces": {
 			"openFiles": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,6 +10,9 @@
 	"forwardPorts": [
 		5003
 	],
+	"runArgs": [
+		"-c", "chmod +x ${containerWorkspaceFolder}/.devcontainer/addcodespacename.sh"
+	],
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "pip install -r requirements.txt",
 	"postAttachCommand": "${containerWorkspaceFolder}/.devcontainer/addcodespacename.sh; python main.py",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,13 +11,8 @@
 		5003
 	],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": 
-	[
-		"chmod +x ${containerWorkspaceFolder}/.devcontainer/addcodespacename.sh",
-		"pip install -r requirements.txt"
-	
-	],
-	"postAttachCommand": "${containerWorkspaceFolder}/.devcontainer/addcodespacename.sh; python main.py",
+	"postCreateCommand": "pip install -r requirements.txt",
+	"postAttachCommand": "chmod +x ${containerWorkspaceFolder}/.devcontainer/addcodespacename.sh; ${containerWorkspaceFolder}/.devcontainer/addcodespacename.sh; python main.py",
 	"customizations": {
 		"codespaces": {
 			"openFiles": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
 	],
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "pip install -r requirements.txt",
-	"postAttachCommand": "python main.py",
+	"postAttachCommand": "${containerWorkspaceFolder}/.devcontainer/addcodespacename.sh; python main.py",
 	"customizations": {
 		"codespaces": {
 			"openFiles": [

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+	"name": "Python 3",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/universal:2",
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [
+		5003
+	],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "pip install -r requirements.txt",
+	"postAttachCommand": "python main.py",
+	"customizations": {
+		"codespaces": {
+			"openFiles": [
+				".well-known/ai-plugin.json",
+				"openapi.yaml"
+			]
+		}
+	}
+	// Configure tool-specific properties.
+	// "customizations": {},
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,8 +11,13 @@
 		5003
 	],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "pip install -r requirements.txt",
-	"postAttachCommand": "chmod +x ${containerWorkspaceFolder}/.devcontainer/addcodespacename.sh; ${containerWorkspaceFolder}/.devcontainer/addcodespacename.sh; python main.py",
+	"postCreateCommand": 
+	[
+		"chmod +x ${containerWorkspaceFolder}/.devcontainer/addcodespacename.sh",
+		"pip install -r requirements.txt"
+	
+	],
+	"postAttachCommand": "${containerWorkspaceFolder}/.devcontainer/addcodespacename.sh; python main.py",
 	"customizations": {
 		"codespaces": {
 			"openFiles": [

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Get a Todo list ChatGPT plugin up and running in under 5 minutes using Python. If you do not already have plugin developer access, please [join the waitlist](https://openai.com/waitlist/plugins).
 
-## Setup
+## Local Setup
 
 To install the required packages for this plugin, run the following command:
 
@@ -25,6 +25,10 @@ Once the local server is running:
 5. Enter in `localhost:5003` since this is the URL the server is running on locally, then select "Find manifest file".
 
 The plugin should now be installed and enabled! You can start with a question like "What is on my todo list" and then try adding something to it as well! 
+
+## GitHub CodeSpaces Setup
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/github.com/${{ github.repository }}?branch=${{ github.ref_name }}&devcontainer_path=/.devcontainer/basics/devcontainer.json)
 
 ## Getting help
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Get a Todo list ChatGPT plugin up and running in under 5 minutes using Python. If you do not already have plugin developer access, please [join the waitlist](https://openai.com/waitlist/plugins).
 
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/openai/plugins-quickstart?devcontainer_path=/.devcontainer/basics/devcontainer.json)
+
 ## Local Setup
 
 To install the required packages for this plugin, run the following command:
@@ -27,8 +29,32 @@ Once the local server is running:
 The plugin should now be installed and enabled! You can start with a question like "What is on my todo list" and then try adding something to it as well! 
 
 ## GitHub CodeSpaces Setup
+_A codespace is a development environment that's hosted in the cloud. You can build and run this plugin via a GitHub Codespace by following the directions below:_ 
 
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/github.com/${{ github.repository }}?branch=${{ github.ref_name }}&devcontainer_path=/.devcontainer/basics/devcontainer.json)
+1. Open this environment in a GitHub Codespace by choosing "Use this template" > "Open in Codespace" as pictured below.
+<img width="191" alt="Green button titled use this template with dropdown options of create new repository and open in codespace" src="https://user-images.githubusercontent.com/22990146/235506864-7be45716-4b61-4986-97b1-e69e3f3a4df4.png">
+
+2. Allow the Codespace a few minutes to finish installing all necessary dependencies. It may take awhile, but keep in mind that GitHub Codespaces is running all the install commands, so you don't have to.
+
+3. Once everything is installed, you should see that a forwarded port is now running the plugin. **Set the port visibility to public.** 
+<img width="1412" alt="Choosing public port visibility for forwarded port" src="https://user-images.githubusercontent.com/22990146/235510002-1a9ef89b-e12c-4145-8119-45daed452028.png">
+
+4. Copy the forwarded port's local address. It should follow this naming convention 
+
+`https://<GITHUB_USER_HANDLE>-<RANDOMLY_GENERATED_PHRASE>-<RANDOMLY_GENERATED_ALPHANUMERIC_STRING>-5003.preview.app.github.dev`
+
+5. Navigate to https://chat.openai.com. 
+
+6. In the Model drop down, select "Plugins" (note, if you don't see it there, you don't have access yet).
+
+7. Select "Plugin store"
+
+8. Select "Develop your own plugin"
+
+9. Enter in the local address to your forwarded port (the one you copied in Step 3), then select "Find manifest file".
+
+
+The plugin should now be installed and enabled! You can start with a question like "What is on my todo list" and then try adding something to it as well! 
 
 ## Getting help
 


### PR DESCRIPTION
I added a devcontainer to this repository along with instructions in the README for how a user can get started.

To test out this implementation, follow the steps for the README using either of the following:
1. GitHub Codespaces - VS Code Web Client
2. GitHub Codespaces - VS Code Desktop with GitHub Codespaces extension

It should work in the two indicated above.


## What's happening in this PR?

- The devcontainer is handles opening up this environment, it runs the commands to install requirements and to run the main.py file.
- The devcontainer also indicates that the forwarded port should be on localhost:5003
- The devcontainer also automatically opens up two files for the developer's ease of use well-known/ai-plugin.json and openapi.yaml
- It also runs a bash script and enables permissions to run the bash script with chmod. This bash script automatically adds the Codespace forwarded port, so that developer's don't have to manual update those files to match the Codespace URL. I did this because your Codespace URL changes with each new Codespace and folks might forget to update it.

## Questions/Concerns
The Codespace seemed to take a bit of a time to finish loading everything. Should I implement a pre-build? 

## Looking for review
I am looking for review from Logan and anyone on the Open AI team. I am also looking for review from anyone on the GitHub side, especially folks within the Codespaces team.

Thank you so much for this opportunity. It was fun!


