### PR TITLE
Fix JSON Syntax Error in Plugin Manifest

### DIFF
--- a/.well-known/ai-plugin.json
+++ b/.well-known/ai-plugin.json
@@ -9,7 +9,7 @@
     },
     "api": {
       "type": "openapi",
-      "url": "http://localhost:5003/openapi.yaml",
+      "url": "http://localhost:5003/openapi.yaml"
     },
     "logo_url": "http://localhost:5003/logo.png",
     "contact_email": "legal@example.com",


### PR DESCRIPTION
This pull request addresses a JSON syntax error in the ai-plugin.json file for the ChatGPT plugin.

Removed the trailing comma in the 'api.url' object within the JSON. This change was necessary because JSON does not allow trailing commas, and the presence of one was causing parsing errors.