### PR TITLE
Remove trailing comma in sample ai-plugin.json

### DIFF
--- a/.well-known/ai-plugin.json
+++ b/.well-known/ai-plugin.json
@@ -9,7 +9,7 @@
     },
     "api": {
       "type": "openapi",
-      "url": "http://localhost:5003/openapi.yaml",
+      "url": "http://localhost:5003/openapi.yaml"
     },
     "logo_url": "http://localhost:5003/logo.png",
     "contact_email": "legal@example.com",


### PR DESCRIPTION
Remove trailing comma (causes JSON parsing issues)