### PR TITLE
correct the json format

### DIFF
--- a/.well-known/ai-plugin.json
+++ b/.well-known/ai-plugin.json
@@ -9,7 +9,7 @@
     },
     "api": {
       "type": "openapi",
-      "url": "http://localhost:5003/openapi.yaml",
+      "url": "http://localhost:5003/openapi.yaml"
     },
     "logo_url": "http://localhost:5003/logo.png",
     "contact_email": "legal@example.com",


### PR DESCRIPTION
The JSON format needs to be corrected; otherwise, the following error will occur when trying to install the local plugin:

> The OpenAI plugin failed to fetch the localhost manifest. Please check to ensure your localhost is running and that your localhost server has CORS enabled.

I believe this issue was introduced through this commit: https://github.com/openai/plugins-quickstart/commit/6e7dcf58be68b2b9caa6739da4ccb3fa512a56ec.