### PR TITLE
Removed trailing comma

### DIFF
--- a/.well-known/ai-plugin.json
+++ b/.well-known/ai-plugin.json
@@ -9,7 +9,7 @@
     },
     "api": {
       "type": "openapi",
-      "url": "http://localhost:5003/openapi.yaml",
+      "url": "http://localhost:5003/openapi.yaml"
     },
     "logo_url": "http://localhost:5003/logo.png",
     "contact_email": "legal@example.com",


### PR DESCRIPTION
The trailing comma was causing this error when trying to load the plugin in ChatGPT:
 "Failed to fetch localhost manifest. Check to ensure your localhost is running and your localhost server has CORS enabled.