### PR TITLE
Update ai-plugin.json to prevent invalid json

### DIFF
--- a/.well-known/ai-plugin.json
+++ b/.well-known/ai-plugin.json
@@ -9,7 +9,7 @@
     },
     "api": {
       "type": "openapi",
-      "url": "http://localhost:5003/openapi.yaml",
+      "url": "http://localhost:5003/openapi.yaml"
     },
     "logo_url": "http://localhost:5003/logo.png",
     "contact_email": "legal@example.com",


### PR DESCRIPTION
The json has a typo (unnecessary comma) preventing the OpenAI GPT-4 plug in reader from finding the manifest for localhost plugins.