### PR TITLE
Add remote URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+REMOTE_URL="https://your-website.com"

--- a/main.py
+++ b/main.py
@@ -1,8 +1,11 @@
 import json
 
+import os
 import quart
 import quart_cors
 from quart import request
+
+REMOTE_URL = os.getenv('REMOTE_URL', None)
 
 app = quart_cors.cors(quart.Quart(__name__), allow_origin="https://chat.openai.com")
 
@@ -40,6 +43,8 @@ async def plugin_manifest():
     host = request.headers['Host']
     with open("./.well-known/ai-plugin.json") as f:
         text = f.read()
+        if REMOTE_URL:
+            text = text.replace("http://localhost:5003", REMOTE_URL)
         return quart.Response(text, mimetype="text/json")
 
 @app.get("/openapi.yaml")
@@ -47,6 +52,8 @@ async def openapi_spec():
     host = request.headers['Host']
     with open("openapi.yaml") as f:
         text = f.read()
+        if REMOTE_URL:
+            text = text.replace("http://localhost:5003", REMOTE_URL)
         return quart.Response(text, mimetype="text/yaml")
 
 def main():


### PR DESCRIPTION
## Issue
When deploying the code remotely, the plugin fails to connect due to the plugin configuration-related files pointing at the wrong URL.

## Description
This PR implements a `REMOTE_URL` environment variable inside the code which allows developers to seamlessly switch between a local environment and a production environment without needing to modify the `openapi.yaml` and `ai-plugin.json` files every time code changes are made and redeployed remotely.

This PR will also work very well with almost all future remote deployment integrations as the developer would only need to add a `REMOTE_URL` environment variable in the deployment service provider's project configuration resulting in a smooth CI/CD pipeline.

## Usage
When running the code locally:
```sh
python main.py
```

When running the code remotely:
```sh
REMOTE_URL=https://your-website.com python main.py
```